### PR TITLE
feat: Add exclusion list for processing items (remove unnecessary files from deployment artefact)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,3 +11,11 @@ plugins:
   - jekyll-redirect-from
 
 github: [metadata]
+
+# Exclude from processing.
+# The following items will not be processed, by default. Create a custom list
+# to override the default setting.
+exclude:
+  - README.md
+  - LICENSE
+  - CNAME


### PR DESCRIPTION
Exclude specific files from processing to override default settings.

Always make sure deployment artefacts don't include anything unwanted!
`LICENSE` is debatable, but the `README.md` really doesn't belong in the deployment artefact.

```
ls _site/* 
_site/404.html          _site/LICENSE           _site/README.md         _site/index.html        _site/redirects.json

_site/assets:
css     fonts   img     js

_site/repo:
index.html
```
